### PR TITLE
Added arguments to run cmd

### DIFF
--- a/PAV/modules/slurmjobcontroller.py
+++ b/PAV/modules/slurmjobcontroller.py
@@ -171,8 +171,7 @@ class SlurmJobController(JobController):
         se = os.environ['PV_JOB_RESULTS_LOG_DIR'] + "/slurm-%j.out"
         so = os.environ['PV_JOB_RESULTS_LOG_DIR'] + "/slurm-%j.out"
         slurm_cmd += " -o " + so + " -e " + se
-
-        run_cmd = os.environ['PV_RUNHOME'] + "/" + self.configs['run']['cmd']
+        run_cmd = os.environ['PV_RUNHOME'] + "/" + self.configs['run']['cmd'] + " " + self.configs['run']['test_args']
         os.environ['USER_CMD'] = run_cmd
 
         # Executable is slurm_job_handler.py which is just the wrapper to call the


### PR DESCRIPTION
After talking to Chris, it seems like having Pavillion run the job with arguments isn't that necessary since they are put in an environment variable. Still, it confused me that the arguments weren't sent along with the command. Here is a small patch to launch the command with the arguments in case you would find it useful.